### PR TITLE
Add zustand / externalize history state to a store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2629,7 +2629,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3475,7 +3475,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -6656,6 +6656,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
     "packages/plugin-echo": {
       "version": "0.1.0",
       "license": "ISC",
@@ -6676,7 +6705,8 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@bytecodealliance/jco": "^1.11.2",

--- a/packages/web-host/package.json
+++ b/packages/web-host/package.json
@@ -34,7 +34,8 @@
 		"qrcode.react": "^4.2.0",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",
-		"tailwind-merge": "^3.3.1"
+		"tailwind-merge": "^3.3.1",
+		"zustand": "^5.0.6"
 	},
 	"devDependencies": {
 		"@bytecodealliance/jco": "^1.11.2",

--- a/packages/web-host/src/components/Repl.tsx
+++ b/packages/web-host/src/components/Repl.tsx
@@ -1,5 +1,6 @@
 import { Play, WandSparkles } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { useReplHistory } from "../hooks/replHistory";
 import { useReplLogic } from "../hooks/replLogic";
 import type { WasmEngine } from "../hooks/wasm";
 import { ReplHistory } from "./ReplHistory";
@@ -33,8 +34,9 @@ export function Repl({
   const inputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const [input, setInput] = useState("");
-  const { handleInput, replHistory, commandRunning } = useReplLogic({ engine });
+  const { handleInput, commandRunning } = useReplLogic({ engine });
   const [inputFocus, setInputFocus] = useState(false);
+  const { history } = useReplHistory();
 
   function handleSubmit(
     event: Pick<
@@ -66,7 +68,7 @@ export function Repl({
       console.log("scrollHeight", historyRef.current.scrollHeight);
       historyRef.current.scrollLeft = 0;
     }
-  }, [replHistory]);
+  }, [history]);
 
   useEffect(() => {
     if (!inputFocus) {
@@ -79,7 +81,7 @@ export function Repl({
       <ReplHistory
         ref={historyRef}
         className="fixed top-[80px] bottom-[100px] overflow-y-scroll max-w-4xl w-full pr-8"
-        history={replHistory}
+        history={history}
       />
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 md:max-w-4xl mx-auto md:border">
         {/** biome-ignore lint/a11y/useSemanticElements: no use of <search> */}

--- a/packages/web-host/src/hooks/replHistory.ts
+++ b/packages/web-host/src/hooks/replHistory.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+
+import type { ReplHistoryEntry } from "../types";
+
+const MAX_HISTORY_LENGTH = 200;
+
+/**
+ * Handles the state of the repl - the history of commands and their results.
+ * @param state
+ * @param payload
+ * @returns
+ */
+function replStateReducer(
+  state: Array<ReplHistoryEntry>,
+  payload: ReplHistoryEntry,
+) {
+  if (state.length >= MAX_HISTORY_LENGTH) {
+    // remove the oldest entry
+    return [...state.slice(1), payload];
+  }
+  return [...state, payload];
+}
+
+const useInnerReplHistory = create<{
+  history: ReplHistoryEntry[];
+  addEntry: (entry: ReplHistoryEntry) => void;
+}>((set) => ({
+  history: [],
+  addEntry: (entry: ReplHistoryEntry) => {
+    set((state: { history: ReplHistoryEntry[] }) => ({
+      history: replStateReducer(state.history, entry),
+    }));
+  },
+}));
+
+export function useReplHistory() {
+  const { addEntry, history } = useInnerReplHistory((state) => state);
+  return {
+    addEntry,
+    history,
+  };
+}

--- a/packages/web-host/src/hooks/wasm.tsx
+++ b/packages/web-host/src/hooks/wasm.tsx
@@ -1,6 +1,7 @@
 import { setReplVar } from "repl:api/host-state";
 import { createContext, useContext, useEffect, useState } from "react";
 import { prepareEngine } from "../wasm/engine";
+import { useReplHistory } from "./replHistory";
 
 type WasmContext =
   | {
@@ -27,13 +28,8 @@ const WasmContext = createContext<WasmContext>({
   engine: null,
 });
 
-// biome-ignore lint/correctness/noUnusedVariables: only used in debug
-// @ts-ignore
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export function WasmProvider({ children }: { children: React.ReactNode }) {
+  const { addEntry: addReplHistoryEntry } = useReplHistory();
   const [context, setContext] = useState<WasmContext>({
     status: "loading",
     error: null,
@@ -42,7 +38,7 @@ export function WasmProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     console.log("useEffect prepareEngine");
-    prepareEngine()
+    prepareEngine({ addReplHistoryEntry })
       .then(async (engine) => {
         // await sleep(1000);
         console.log("useEffect prepareEngine success", engine);
@@ -63,7 +59,7 @@ export function WasmProvider({ children }: { children: React.ReactNode }) {
           engine: null,
         });
       });
-  }, []);
+  }, [addReplHistoryEntry]);
 
   return (
     <WasmContext.Provider value={context}>{children}</WasmContext.Provider>


### PR DESCRIPTION
Using Zustand for centralized REPL history management:

- enabling history persistence across page navigation
- allowing history updates during WASM engine boot