### PR TITLE
Use `npm ci` instead of `npm install` in GitHub Actions

### DIFF
--- a/.github/workflows/web-host.yml
+++ b/.github/workflows/web-host.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install cargo-component
         run: cargo binstall cargo-component@0.21.1
       - name: Install JavaScript dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run web-host:build
       - name: Cache build artifacts


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use `npm ci` instead of `npm install` for installing JavaScript dependencies. This change improves build reliability and performance in CI/CD environments.

### Changes Made

- **File:** `.github/workflows/web-host.yml`
- **Change:** Replace `npm install` with `npm ci` in the "Install JavaScript dependencies" step

### Why `npm ci`?

- **Faster installation:** `npm ci` is optimized for continuous integration environments
- **Deterministic builds:** Ensures exact dependency versions are installed based on `package-lock.json`
- **Cleaner environment:** Automatically removes `node_modules` before installation
- **Better error handling:** Fails fast if `package-lock.json` is out of sync with `package.json`

### Documentation References

- [npm ci - npm Documentation](https://docs.npmjs.com/cli/v10/commands/npm-ci)

### Impact

- ✅ Improved build reliability
- ✅ Faster CI builds
- ✅ Ensures consistent dependency versions across environments
- ✅ No breaking changes to the application

This is a safe change that follows npm best practices for CI/CD workflows.