### PR TITLE
Add C Language Plugin Support

### DIFF
--- a/.env.original
+++ b/.env.original
@@ -1,0 +1,5 @@
+# see https://github.com/WebAssembly/wasi-sdk/releases for exact possibilities
+WASI_OS=macos # 'macos' | 'linux' | ''windows'
+WASI_ARCH=x86_64 # 'x86_64' | 'arm64'
+WASI_VERSION=25
+WASI_VERSION_FULL=${WASI_VERSION}.0

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -5,6 +5,20 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Set variables based on OS and architecture for just dl-wasi-sdk
+        run: |
+          if [ "${{ runner.arch }}" = "X64" ]; then
+            echo "WASI_ARCH=x86_64" >> $GITHUB_ENV
+          else
+            echo "WASI_ARCH=arm64" >> $GITHUB_ENV
+          fi
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "WASI_OS=windows" >> $GITHUB_ENV
+          else
+            echo "WASI_OS=linux" >> $GITHUB_ENV
+          fi
+          echo "WASI_VERSION_FULL=25.0" >> $GITHUB_ENV
+          echo "WASI_VERSION=25" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
@@ -15,6 +29,14 @@ jobs:
       - uses: extractions/setup-just@v3
       - name: Install cargo-component
         run: cargo binstall cargo-component@0.21.1
+      - name: Install wasm-tools
+        run: cargo binstall wasm-tools@1.235.0
+      - name: Install wit-bindgen
+        run: cargo install wit-bindgen-cli@0.43.0
+      - name: Install wasi-sdk
+        run: |
+          mkdir c_deps
+          just dl-wasi-sdk
       - name: Build
         run: just build
       - name: Test

--- a/.github/workflows/web-host.yml
+++ b/.github/workflows/web-host.yml
@@ -5,6 +5,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set variables based on OS and architecture for just dl-wasi-sdk
+        run: |
+          if [ "${{ runner.arch }}" = "X64" ]; then
+            echo "WASI_ARCH=x86_64" >> $GITHUB_ENV
+          else
+            echo "WASI_ARCH=arm64" >> $GITHUB_ENV
+          fi
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "WASI_OS=windows" >> $GITHUB_ENV
+          else
+            echo "WASI_OS=linux" >> $GITHUB_ENV
+          fi
+          echo "WASI_VERSION_FULL=25.0" >> $GITHUB_ENV
+          echo "WASI_VERSION=25" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
@@ -18,6 +32,14 @@ jobs:
       - uses: extractions/setup-just@v3
       - name: Install cargo-component
         run: cargo binstall cargo-component@0.21.1
+      - name: Install wasm-tools
+        run: cargo binstall wasm-tools@1.235.0
+      - name: Install wit-bindgen
+        run: cargo install wit-bindgen-cli@0.43.0
+      - name: Install wasi-sdk
+        run: |
+          mkdir c_deps
+          just dl-wasi-sdk
       - name: Install JavaScript dependencies
         run: npm ci
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,3 @@ dist/
 # C
 .env
 c_deps/
-
-# wit-bindgen generated files for C plugins
-c_modules/*/plugin_api.h
-c_modules/*/plugin_api.c
-c_modules/*/plugin_api_component_type.o

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist/
 
 # C
 .env
+c_deps/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target/
 ### JavaScript ###
 node_modules/
 dist/
+
+# C
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ dist/
 # C
 .env
 c_deps/
+
+# wit-bindgen generated files for C plugins
+c_modules/*/plugin_api.h
+c_modules/*/plugin_api.c
+c_modules/*/plugin_api_component_type.o

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "skellock.just",
     "biomejs.biome",
     "bradlc.vscode-tailwindcss",
-    "ms-playwright.playwright"
+    "ms-playwright.playwright",
+    "ms-vscode.cpptools"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are two kinds of hosts:
 Those hosts then run the same codebase which is compiled to WebAssembly:
 
 - the REPL logic
-- the plugins
+- the plugins (made a few in rust, C and TypeScript)
 
 Security model: the REPL cli implements a security model inspired by [deno](https://docs.deno.com/runtime/fundamentals/security/#permissions):
 
@@ -82,6 +82,7 @@ pluginlab\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_echo.wasm\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_weather.wasm\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_cat.wasm\
+  --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_echo-c.wasm\
   --allow-all
 ```
 
@@ -105,6 +106,7 @@ pluginlab\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_echo.wasm\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_weather.wasm\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_cat.wasm\
+  --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_echo-c.wasm\
   --allow-all
 [Host] Starting REPL host...
 [Host] Loading REPL logic from: https://topheman.github.io/webassembly-component-model-experiments/plugins/repl_logic_guest.wasm
@@ -206,6 +208,7 @@ This will (see [justfile](./justfile)):
 - compile the pluginlab crate from rust to a binary file
 - compile the repl-logic-guest crate from rust to wasm
 - compile the plugin-* crates from rust to wasm
+- compile the c_modules/plugin-* C plugins to wasm
 
 #### Run
 
@@ -217,6 +220,7 @@ This will (see [justfile](./justfile)):
   --plugins ./target/wasm32-wasip1/debug/plugin_echo.wasm\
   --plugins ./target/wasm32-wasip1/debug/plugin_weather.wasm\
   --plugins ./target/wasm32-wasip1/debug/plugin_cat.wasm\
+  --plugins ./c_modules/plugin-echo/plugin-echo-c.wasm\
   --allow-all
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ cargo install wit-bindgen-cli@0.43.0
 cargo binstall wasm-tools@1.235.0
 ```
 
+```bash
+# Download the WASI SDK into ./c_deps/wasi-sdk folder
+just dl-wasi-sdk
+```
+
 ### pluginlab (rust)
 
 #### Build

--- a/README.md
+++ b/README.md
@@ -169,6 +169,25 @@ npm install
 npx playwright install
 ```
 
+#### C tooling
+
+[From the WebAssembly Component Model section for C tooling](https://component-model.bytecodealliance.org/language-support/c.html)
+
+```bash
+# Initialize the .env file tracking the WASI SDK version for C development
+# You will be asked to update the WASI_OS and WASI_ARCH variables if needed
+just init-env-file
+```
+
+```bash
+cargo install wit-bindgen-cli@0.43.0
+```
+
+```bash
+# Install the wasm-tools tool - you can also use cargo install wasm-tools@1.235.0 if you don't have cargo-binstall
+cargo binstall wasm-tools@1.235.0
+```
+
 ### pluginlab (rust)
 
 #### Build
@@ -346,6 +365,7 @@ Those are **optional** tools that are handy for WebAssembly development:
 - [cargo component 0.21.1+](https://github.com/bytecodealliance/cargo-component?tab=readme-ov-file#installation)
 - [wasm-tools 1.235.0](https://github.com/bytecodealliance/wasm-tools?tab=readme-ov-file#installation)
 - [wasm-opt 116](https://github.com/WebAssembly/binaryen?tab=readme-ov-file#installation)
+- [wit-bindgen-cli 0.43.0](https://github.com/bytecodealliance/wit-bindgen)
 
 ```bash
 # latest versions
@@ -356,3 +376,9 @@ cargo binstall cargo-component wasm-tools wasm-opt
 # specific versions I used for this project
 cargo binstall cargo-component@0.21.1 wasm-tools@1.235.0 wasm-opt@116
 ```
+
+### C tooling
+
+- [From the WebAssembly Component Model section for C tooling](https://component-model.bytecodealliance.org/language-support/c.html)
+- [WASI SDK](https://github.com/WebAssembly/wasi-sdk)
+- [WIT Bindgen](https://github.com/bytecodealliance/wit-bindgen)

--- a/c_modules/README.md
+++ b/c_modules/README.md
@@ -1,0 +1,9 @@
+# Plugins written in C
+
+You can find here plugins written in C, some are re-implementations of the plugins written in Rust.
+
+The `plugin_api.c`, `plugin_api.h` and `plugin_api.component_type.o` are generated with [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen), based on the [wit files](../crates/pluginlab/wit) of the project.
+
+The wasm files are compiled with the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) you downloaded with `just dl-wasi-sdk`, which contain the `clang` compiler.
+
+All you have to do is run `just build` to build everything (including the C plugins) and `just test` to run the tests (including the C plugins).

--- a/c_modules/plugin-echo/.gitignore
+++ b/c_modules/plugin-echo/.gitignore
@@ -1,0 +1,4 @@
+*.wasm
+plugin_api.h
+plugin_api.c
+plugin_api_component_type.o

--- a/c_modules/plugin-echo/component.c
+++ b/c_modules/plugin-echo/component.c
@@ -1,0 +1,67 @@
+#include "plugin_api.h"
+#include <string.h>
+#include <stdlib.h>
+
+/*
+ * C implementation of the echo plugin
+ *
+ * IMPLEMENTATION SOURCE:
+ * This implements the same interface as the Rust version in crates/plugin-echo/src/lib.rs
+ * The function signatures are generated from the WIT interface by wit-bindgen:
+ * - exports_repl_api_plugin_name() corresponds to fn name() -> String
+ * - exports_repl_api_plugin_man() corresponds to fn man() -> String
+ * - exports_repl_api_plugin_run() corresponds to fn run(payload: String) -> Result<PluginResponse, ()>
+ *
+ * MEMORY MANAGEMENT:
+ * - Input parameters (like payload) are owned by the runtime - DO NOT free them
+ * - Output parameters (like ret) are populated by us, freed by the runtime
+ * - plugin_api_string_dup() allocates new memory for string copies
+ * - The generated _free functions handle cleanup automatically
+ * - No explicit free() calls needed in plugin code
+ */
+
+void exports_repl_api_plugin_name(plugin_api_string_t *ret)
+{
+    // Populate ret with "echo" as the plugin name
+    // plugin_api_string_dup() allocates new memory and copies the string
+    plugin_api_string_dup(ret, "echoc");
+}
+
+void exports_repl_api_plugin_man(plugin_api_string_t *ret)
+{
+    // Populate ret with the manual text for the echo command
+    // plugin_api_string_dup() allocates new memory and copies the string
+    const char *man_text =
+        "\n"
+        "NAME\n"
+        "    echoc - Echo a message (built with C)\n"
+        "\n"
+        "USAGE\n"
+        "    echoc <message>\n"
+        "\n"
+        "DESCRIPTION\n"
+        "    Echo a message.\n"
+        "\n"
+        "        ";
+    plugin_api_string_dup(ret, man_text);
+}
+
+bool exports_repl_api_plugin_run(plugin_api_string_t *payload, exports_repl_api_plugin_plugin_response_t *ret)
+{
+    // Set status to success (0 = success, 1 = error)
+    ret->status = REPL_API_TRANSPORT_REPL_STATUS_SUCCESS;
+
+    // Set stdout to contain the payload
+    // is_some = true means the optional string has a value
+    ret->stdout.is_some = true;
+    // plugin_api_string_dup() creates a new copy of payload->ptr in ret->stdout.val
+    // This allocates new memory and copies the string content
+    plugin_api_string_dup(&ret->stdout.val, (const char *)payload->ptr);
+
+    // Set stderr to none (no error output)
+    ret->stderr.is_some = false;
+
+    // Return true for success (false would indicate an error)
+    // This corresponds to Ok(response) in the Rust Result<T, ()> pattern
+    return true;
+}

--- a/crates/pluginlab/README.md
+++ b/crates/pluginlab/README.md
@@ -18,7 +18,7 @@ There are two kinds of hosts:
 Those hosts then run the same codebase which is compiled to WebAssembly:
 
 - the REPL logic
-- the plugins
+- the plugins (made a few in rust, C and TypeScript)
 
 Security model: the REPL cli implements a security model inspired by [deno](https://docs.deno.com/runtime/fundamentals/security/#permissions):
 
@@ -61,6 +61,7 @@ pluginlab\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_echo.wasm\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_weather.wasm\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_cat.wasm\
+  --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_echo-c.wasm\
   --allow-all
 ```
 
@@ -85,6 +86,7 @@ pluginlab\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_echo.wasm\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_weather.wasm\
   --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_cat.wasm\
+  --plugins https://topheman.github.io/webassembly-component-model-experiments/plugins/plugin_echo-c.wasm\
   --allow-all
 [Host] Starting REPL host...
 [Host] Loading REPL logic from: https://topheman.github.io/webassembly-component-model-experiments/plugins/repl_logic_guest.wasm

--- a/crates/pluginlab/tests/e2e_c_plugins.rs
+++ b/crates/pluginlab/tests/e2e_c_plugins.rs
@@ -27,7 +27,6 @@ mod e2e_c_plugins {
     }
 
     #[test]
-    #[ignore = "C echo plugin is still failing the test"]
     fn test_echo_plugin() {
         let project_root = find_project_root();
         println!("Setting current directory to: {:?}", project_root);

--- a/crates/pluginlab/tests/e2e_c_plugins.rs
+++ b/crates/pluginlab/tests/e2e_c_plugins.rs
@@ -1,0 +1,63 @@
+mod utils;
+
+#[cfg(test)]
+mod e2e_c_plugins {
+
+    use crate::utils::*;
+
+    use rexpect::spawn;
+
+    const TEST_TIMEOUT: u64 = 10000;
+
+    /**
+     * Lets us change the target directory for the plugins and repl logic.
+     *
+     * See the justfile for examples where we switch to testing both plugins from the filesystem and from the HTTP server.
+     */
+    fn build_command(plugin_files: &[&str], repl_logic_file: &str) -> String {
+        let prefix =
+            std::env::var("WASM_TARGET_DIR").unwrap_or("target/wasm32-wasip1/debug".to_string());
+        let mut command = String::from("target/debug/pluginlab");
+        command.push_str(format!(" --repl-logic {}/{}", prefix, repl_logic_file).as_str());
+        plugin_files.iter().for_each(|file| {
+            command.push_str(format!(" --plugins {}", file).as_str());
+        });
+        println!("Running command: {}", command);
+        command
+    }
+
+    #[test]
+    #[ignore = "C echo plugin is still failing the test"]
+    fn test_echo_plugin() {
+        let project_root = find_project_root();
+        println!("Setting current directory to: {:?}", project_root);
+        std::env::set_current_dir(&project_root).unwrap();
+        let mut session = spawn(
+            &format!(
+                "{} --dir tmp/filesystem --allow-read",
+                &build_command(
+                    &["c_modules/plugin-echo/plugin-echo-c.component.wasm"],
+                    "repl_logic_guest.wasm"
+                )
+            ),
+            Some(TEST_TIMEOUT),
+        )
+        .expect("Can't launch pluginlab with plugin greet");
+
+        session
+            .exp_string("[Host] Starting REPL host...")
+            .expect("Didn't see startup message");
+        session
+            .exp_string("[Host] Loading plugin:")
+            .expect("Didn't see plugin loading message");
+        session
+            .exp_string("repl(0)>")
+            .expect("Didn't see REPL prompt");
+        session
+            .send_line("echoc hello")
+            .expect("Failed to send command");
+        session
+            .exp_string("hello\r\nrepl(0)>")
+            .expect("Didn't get expected output from echoc plugin");
+    }
+}

--- a/crates/pluginlab/tests/e2e_c_plugins.rs
+++ b/crates/pluginlab/tests/e2e_c_plugins.rs
@@ -35,7 +35,7 @@ mod e2e_c_plugins {
             &format!(
                 "{} --dir tmp/filesystem --allow-read",
                 &build_command(
-                    &["c_modules/plugin-echo/plugin-echo-c.component.wasm"],
+                    &["c_modules/plugin-echo/plugin-echo-c.wasm"],
                     "repl_logic_guest.wasm"
                 )
             ),

--- a/crates/pluginlab/tests/e2e_rust_plugins.rs
+++ b/crates/pluginlab/tests/e2e_rust_plugins.rs
@@ -27,6 +27,68 @@ mod e2e_rust_plugins {
     }
 
     #[test]
+    fn test_echo_plugin() {
+        let project_root = find_project_root();
+        println!("Setting current directory to: {:?}", project_root);
+        std::env::set_current_dir(&project_root).unwrap();
+        let mut session = spawn(
+            &format!(
+                "{} --dir tmp/filesystem --allow-read",
+                &build_command(&["plugin_echo.wasm"], "repl_logic_guest.wasm")
+            ),
+            Some(TEST_TIMEOUT),
+        )
+        .expect("Can't launch pluginlab with plugin greet");
+
+        session
+            .exp_string("[Host] Starting REPL host...")
+            .expect("Didn't see startup message");
+        session
+            .exp_string("[Host] Loading plugin:")
+            .expect("Didn't see plugin loading message");
+        session
+            .exp_string("repl(0)>")
+            .expect("Didn't see REPL prompt");
+        session
+            .send_line("echo hello")
+            .expect("Failed to send command");
+        session
+            .exp_string("hello\r\n")
+            .expect("Didn't get expected output from echo plugin");
+    }
+
+    #[test]
+    fn test_greet_plugin() {
+        let project_root = find_project_root();
+        println!("Setting current directory to: {:?}", project_root);
+        std::env::set_current_dir(&project_root).unwrap();
+        let mut session = spawn(
+            &format!(
+                "{} --dir tmp/filesystem --allow-read",
+                &build_command(&["plugin_greet.wasm"], "repl_logic_guest.wasm")
+            ),
+            Some(TEST_TIMEOUT),
+        )
+        .expect("Can't launch pluginlab with plugin greet");
+
+        session
+            .exp_string("[Host] Starting REPL host...")
+            .expect("Didn't see startup message");
+        session
+            .exp_string("[Host] Loading plugin:")
+            .expect("Didn't see plugin loading message");
+        session
+            .exp_string("repl(0)>")
+            .expect("Didn't see REPL prompt");
+        session
+            .send_line("greet World")
+            .expect("Failed to send command");
+        session
+            .exp_string("Hello, World!\r\n")
+            .expect("Didn't get expected output from greet plugin");
+    }
+
+    #[test]
     fn test_ls_plugin() {
         let project_root = find_project_root();
         println!("Setting current directory to: {:?}", project_root);

--- a/crates/pluginlab/tests/e2e_rust_plugins.rs
+++ b/crates/pluginlab/tests/e2e_rust_plugins.rs
@@ -1,0 +1,114 @@
+mod utils;
+
+#[cfg(test)]
+mod e2e_rust_plugins {
+
+    use crate::utils::*;
+
+    use rexpect::spawn;
+
+    const TEST_TIMEOUT: u64 = 10000;
+
+    /**
+     * Lets us change the target directory for the plugins and repl logic.
+     *
+     * See the justfile for examples where we switch to testing both plugins from the filesystem and from the HTTP server.
+     */
+    fn build_command(plugin_files: &[&str], repl_logic_file: &str) -> String {
+        let prefix =
+            std::env::var("WASM_TARGET_DIR").unwrap_or("target/wasm32-wasip1/debug".to_string());
+        let mut command = String::from("target/debug/pluginlab");
+        command.push_str(format!(" --repl-logic {}/{}", prefix, repl_logic_file).as_str());
+        plugin_files.iter().for_each(|file| {
+            command.push_str(format!(" --plugins {}/{}", prefix, file).as_str());
+        });
+        println!("Running command: {}", command);
+        command
+    }
+
+    #[test]
+    fn test_ls_plugin() {
+        let project_root = find_project_root();
+        println!("Setting current directory to: {:?}", project_root);
+        std::env::set_current_dir(&project_root).unwrap();
+        let mut session = spawn(
+            &format!(
+                "{} --dir tmp/filesystem --allow-read",
+                &build_command(&["plugin_ls.wasm"], "repl_logic_guest.wasm")
+            ),
+            Some(TEST_TIMEOUT),
+        )
+        .expect("Can't launch pluginlab with plugin greet");
+
+        session
+            .exp_string("[Host] Starting REPL host...")
+            .expect("Didn't see startup message");
+        session
+            .exp_string("[Host] Loading plugin:")
+            .expect("Didn't see plugin loading message");
+        session
+            .exp_string("repl(0)>")
+            .expect("Didn't see REPL prompt");
+        session.send_line("ls").expect("Failed to send command");
+        session
+            .exp_string(
+                "D\tdata\r\nD\tdocuments\r\nD\tlogs\r\nF\t.config\r\nF\t.hidden_file\r\nF\tREADME.md\r\n",
+            )
+            .expect("Didn't get listing of current directory");
+        session
+            .send_line("ls documents")
+            .expect("Failed to send command");
+        session
+            .exp_string("D\tdocuments/work\r\nF\tdocuments/README.md\r\nF\tdocuments/config.json\r\nF\tdocuments/notes.txt\r\n")
+            .expect("Didn't get listing of documents directory");
+        session
+            .send_line("ls documents/work/projects")
+            .expect("Failed to send command");
+        session
+            .exp_string("D\tdocuments/work/projects/alpha\r\nD\tdocuments/work/projects/beta\r\nF\tdocuments/work/projects/.gitkeep\r\n")
+            .expect("Didn't get listing of projects directory");
+        session
+            .send_line("ls data/sample.csv")
+            .expect("Failed to send command");
+        session
+            .exp_string("F\tdata/sample.csv\r\n")
+            .expect("Didn't get listing for a single file");
+    }
+
+    #[test]
+    fn test_cat_plugin() {
+        let project_root = find_project_root();
+        println!("Setting current directory to: {:?}", project_root);
+        std::env::set_current_dir(&project_root).unwrap();
+        let mut session = spawn(
+            &format!(
+                "{} --dir tmp/filesystem --allow-read",
+                &build_command(&["plugin_cat.wasm"], "repl_logic_guest.wasm")
+            ),
+            Some(TEST_TIMEOUT),
+        )
+        .expect("Can't launch pluginlab with plugin greet");
+
+        session
+            .exp_string("[Host] Starting REPL host...")
+            .expect("Didn't see startup message");
+        session
+            .exp_string("[Host] Loading plugin:")
+            .expect("Didn't see plugin loading message");
+        session
+            .exp_string("repl(0)>")
+            .expect("Didn't see REPL prompt");
+        session
+            .send_line("cat documents")
+            .expect("Failed to send command");
+        session
+            .exp_string("cat: documents: Is a directory")
+            .expect("Didn't get expected error output for trying to cat a directory");
+        session
+            .send_line("cat documents/README.md")
+            .expect("Failed to send command");
+        session
+            .exp_string("# Documents")
+            .expect("Didn't get expected contents of README.md");
+    }
+}

--- a/crates/pluginlab/tests/e2e_rust_plugins.rs
+++ b/crates/pluginlab/tests/e2e_rust_plugins.rs
@@ -53,7 +53,7 @@ mod e2e_rust_plugins {
             .send_line("echo hello")
             .expect("Failed to send command");
         session
-            .exp_string("hello\r\n")
+            .exp_string("hello\r\nrepl(0)>")
             .expect("Didn't get expected output from echo plugin");
     }
 
@@ -84,7 +84,7 @@ mod e2e_rust_plugins {
             .send_line("greet World")
             .expect("Failed to send command");
         session
-            .exp_string("Hello, World!\r\n")
+            .exp_string("Hello, World!\r\nrepl(0)>")
             .expect("Didn't get expected output from greet plugin");
     }
 

--- a/crates/pluginlab/tests/e2e_rust_repl_logic.rs
+++ b/crates/pluginlab/tests/e2e_rust_repl_logic.rs
@@ -1,8 +1,11 @@
+mod utils;
+
 #[cfg(test)]
-mod e2e_test {
+mod e2e_rust_repl_logic {
+
+    use crate::utils::*;
 
     use rexpect::spawn;
-    use std::path::PathBuf;
 
     const TEST_TIMEOUT: u64 = 10000;
 
@@ -21,30 +24,6 @@ mod e2e_test {
         });
         println!("Running command: {}", command);
         command
-    }
-
-    fn find_project_root() -> PathBuf {
-        let mut current = std::env::current_dir().unwrap();
-        println!("Starting search from: {:?}", current);
-
-        // Walk up the directory tree looking for the workspace root Cargo.toml
-        loop {
-            let cargo_toml = current.join("Cargo.toml");
-            if cargo_toml.exists() {
-                // Check if this is the workspace root by looking for [workspace] section
-                if let Ok(content) = std::fs::read_to_string(&cargo_toml) {
-                    if content.contains("[workspace]") {
-                        println!("Found workspace root at: {:?}", current);
-                        return current;
-                    }
-                }
-            }
-
-            if !current.pop() {
-                // current.pop() moves up one directory in the path. If we're already at the root, it returns false.
-                panic!("Could not find workspace root (Cargo.toml with [workspace])");
-            }
-        }
     }
 
     #[test]
@@ -217,92 +196,6 @@ mod e2e_test {
         session
             .exp_string("0")
             .expect("Didn't get expected echo output for $? after previous command succeeded");
-    }
-
-    #[test]
-    fn test_ls_plugin() {
-        let project_root = find_project_root();
-        println!("Setting current directory to: {:?}", project_root);
-        std::env::set_current_dir(&project_root).unwrap();
-        let mut session = spawn(
-            &format!(
-                "{} --dir tmp/filesystem --allow-read",
-                &build_command(&["plugin_ls.wasm"], "repl_logic_guest.wasm")
-            ),
-            Some(TEST_TIMEOUT),
-        )
-        .expect("Can't launch pluginlab with plugin greet");
-
-        session
-            .exp_string("[Host] Starting REPL host...")
-            .expect("Didn't see startup message");
-        session
-            .exp_string("[Host] Loading plugin:")
-            .expect("Didn't see plugin loading message");
-        session
-            .exp_string("repl(0)>")
-            .expect("Didn't see REPL prompt");
-        session.send_line("ls").expect("Failed to send command");
-        session
-            .exp_string(
-                "D\tdata\r\nD\tdocuments\r\nD\tlogs\r\nF\t.config\r\nF\t.hidden_file\r\nF\tREADME.md\r\n",
-            )
-            .expect("Didn't get listing of current directory");
-        session
-            .send_line("ls documents")
-            .expect("Failed to send command");
-        session
-            .exp_string("D\tdocuments/work\r\nF\tdocuments/README.md\r\nF\tdocuments/config.json\r\nF\tdocuments/notes.txt\r\n")
-            .expect("Didn't get listing of documents directory");
-        session
-            .send_line("ls documents/work/projects")
-            .expect("Failed to send command");
-        session
-            .exp_string("D\tdocuments/work/projects/alpha\r\nD\tdocuments/work/projects/beta\r\nF\tdocuments/work/projects/.gitkeep\r\n")
-            .expect("Didn't get listing of projects directory");
-        session
-            .send_line("ls data/sample.csv")
-            .expect("Failed to send command");
-        session
-            .exp_string("F\tdata/sample.csv\r\n")
-            .expect("Didn't get listing for a single file");
-    }
-
-    #[test]
-    fn test_cat_plugin() {
-        let project_root = find_project_root();
-        println!("Setting current directory to: {:?}", project_root);
-        std::env::set_current_dir(&project_root).unwrap();
-        let mut session = spawn(
-            &format!(
-                "{} --dir tmp/filesystem --allow-read",
-                &build_command(&["plugin_cat.wasm"], "repl_logic_guest.wasm")
-            ),
-            Some(TEST_TIMEOUT),
-        )
-        .expect("Can't launch pluginlab with plugin greet");
-
-        session
-            .exp_string("[Host] Starting REPL host...")
-            .expect("Didn't see startup message");
-        session
-            .exp_string("[Host] Loading plugin:")
-            .expect("Didn't see plugin loading message");
-        session
-            .exp_string("repl(0)>")
-            .expect("Didn't see REPL prompt");
-        session
-            .send_line("cat documents")
-            .expect("Failed to send command");
-        session
-            .exp_string("cat: documents: Is a directory")
-            .expect("Didn't get expected error output for trying to cat a directory");
-        session
-            .send_line("cat documents/README.md")
-            .expect("Failed to send command");
-        session
-            .exp_string("# Documents")
-            .expect("Didn't get expected contents of README.md");
     }
 
     #[test]

--- a/crates/pluginlab/tests/utils.rs
+++ b/crates/pluginlab/tests/utils.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+
+pub fn find_project_root() -> PathBuf {
+    let mut current = std::env::current_dir().unwrap();
+    println!("Starting search from: {:?}", current);
+
+    // Walk up the directory tree looking for the workspace root Cargo.toml
+    loop {
+        let cargo_toml = current.join("Cargo.toml");
+        if cargo_toml.exists() {
+            // Check if this is the workspace root by looking for [workspace] section
+            if let Ok(content) = std::fs::read_to_string(&cargo_toml) {
+                if content.contains("[workspace]") {
+                    println!("Found workspace root at: {:?}", current);
+                    return current;
+                }
+            }
+        }
+
+        if !current.pop() {
+            // current.pop() moves up one directory in the path. If we're already at the root, it returns false.
+            panic!("Could not find workspace root (Cargo.toml with [workspace])");
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -11,6 +11,15 @@ init-env-file:
     @echo ""
     @echo "Currently, in .env file, WASI_OS=$WASI_OS and WASI_ARCH=$WASI_ARCH, please update them if needed."
 
+#Download the WASI SDK into ./c_deps/wasi-sdk folder - run `just init-env-file` before
+dl-wasi-sdk:
+    #!/usr/bin/env bash
+    mkdir -p c_deps
+    FILENAME=wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
+    curl -L -o c_deps/${FILENAME} https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/${FILENAME}
+    tar -C c_deps -xvf c_deps/${FILENAME}
+    mv c_deps/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS} c_deps/wasi-sdk
+
 wasi-sdk-name:
     @echo wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
 

--- a/justfile
+++ b/justfile
@@ -121,7 +121,7 @@ list-rust-plugins:
 # List all the C plugins
 list-c-plugins:
     #!/usr/bin/env bash
-    ls -1 c_modules
+    ls -1 c_modules|grep plugin-
 
 # Run the tests for the pluginlab
 test: build-repl-logic-guest build-plugins prepare-fixtures

--- a/justfile
+++ b/justfile
@@ -32,6 +32,7 @@ c-wit-bindgen-plugins:
 # Build a specific C plugin
 build-c-plugin plugin:
     #!/usr/bin/env bash
+    just c-wit-bindgen-plugin {{plugin}}
     ./c_deps/wasi-sdk/bin/clang ./c_modules/{{plugin}}/component.c ./c_modules/{{plugin}}/plugin_api.c ./c_modules/{{plugin}}/plugin_api_component_type.o -o ./c_modules/{{plugin}}/{{plugin}}-c.wasm -mexec-model=reactor
     wasm-tools component new ./c_modules/{{plugin}}/{{plugin}}-c.wasm -o ./c_modules/{{plugin}}/{{plugin}}-c.component.wasm
 
@@ -44,11 +45,11 @@ wasi-sdk-name:
     @echo wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
 
 # Build all crates with appropriate commands
-build: build-repl-logic-guest build-plugins
+build: build-repl-logic-guest build-plugins build-c-plugins
     just build-pluginlab
 
 # Build all crates in release mode
-build-release: build-repl-logic-guest-release build-plugins-release
+build-release: build-repl-logic-guest-release build-plugins-release build-c-plugins
     just build-pluginlab-release
 
 # Build all plugins in debug mode

--- a/justfile
+++ b/justfile
@@ -20,6 +20,15 @@ dl-wasi-sdk:
     tar -C c_deps -xvf c_deps/${FILENAME}
     mv c_deps/wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS} c_deps/wasi-sdk
 
+# Generate the C bindings for the plugin
+c-wit-bindgen-plugin plugin:
+    wit-bindgen c ./crates/pluginlab/wit --world plugin-api --out-dir ./c_modules/{{plugin}}
+
+# Generate the C bindings for all plugins
+c-wit-bindgen-plugins:
+    #!/usr/bin/env bash
+    just list-c-plugins|xargs -I {} just c-wit-bindgen-plugin {}
+
 wasi-sdk-name:
     @echo wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
 
@@ -82,6 +91,11 @@ clean:
 list-rust-plugins:
     #!/usr/bin/env bash
     ls -1 crates|grep plugin-
+
+# List all the C plugins
+list-c-plugins:
+    #!/usr/bin/env bash
+    ls -1 c_modules
 
 # Run the tests for the pluginlab
 test: build-repl-logic-guest build-plugins prepare-fixtures

--- a/justfile
+++ b/justfile
@@ -1,6 +1,18 @@
+set dotenv-load
+
 # Show help
 default:
     @just --list
+
+# Initialize the .env file tracking the WASI SDK version
+init-env-file:
+    cp .env.original .env
+    cat .env
+    @echo ""
+    @echo "Currently, in .env file, WASI_OS=$WASI_OS and WASI_ARCH=$WASI_ARCH, please update them if needed."
+
+wasi-sdk-name:
+    @echo wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
 
 # Build all crates with appropriate commands
 build: build-repl-logic-guest build-plugins

--- a/justfile
+++ b/justfile
@@ -29,6 +29,17 @@ c-wit-bindgen-plugins:
     #!/usr/bin/env bash
     just list-c-plugins|xargs -I {} just c-wit-bindgen-plugin {}
 
+# Build a specific C plugin
+build-c-plugin plugin:
+    #!/usr/bin/env bash
+    ./c_deps/wasi-sdk/bin/clang ./c_modules/{{plugin}}/component.c ./c_modules/{{plugin}}/plugin_api.c ./c_modules/{{plugin}}/plugin_api_component_type.o -o ./c_modules/{{plugin}}/{{plugin}}-c.wasm -mexec-model=reactor
+    wasm-tools component new ./c_modules/{{plugin}}/{{plugin}}-c.wasm -o ./c_modules/{{plugin}}/{{plugin}}-c.component.wasm
+
+# Build all C plugins
+build-c-plugins:
+    #!/usr/bin/env bash
+    just list-c-plugins|xargs -I {} just build-c-plugin {}
+
 wasi-sdk-name:
     @echo wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}.tar.gz
 

--- a/packages/web-host/clis/prepareWasmFiles.ts
+++ b/packages/web-host/clis/prepareWasmFiles.ts
@@ -25,6 +25,10 @@ const wasmFiles: Array<{ debug: string; release: string }> = [
     release: "target/wasm32-wasip1/release/plugin_weather.wasm",
   },
   {
+    debug: "c_modules/plugin-echo/plugin-echo-c.wasm",
+    release: "c_modules/plugin-echo/plugin-echo-c.wasm",
+  },
+  {
     debug: "target/wasm32-wasip1/debug/repl_logic_guest.wasm",
     release: "target/wasm32-wasip1/release/repl_logic_guest.wasm",
   },


### PR DESCRIPTION
This PR introduces support for WebAssembly Component Model plugins written in C, expanding the plugin ecosystem beyond Rust implementations.

## ✨ Key Features

- **C Plugin Infrastructure**: Added complete toolchain and build system for C-based plugins
- **Echo Plugin Implementation**: Created a C version of the echo plugin (`c_modules/plugin-echo/component.c`) as a reference implementation
- **WASI SDK Integration**: Integrated wasi-sdk for compiling C code to WebAssembly components
- **CI/CD Updates**: Added wasi-sdk download step to CI workflows for both Rust host and web host

## 🔧 Technical Implementation

- **Memory Management**: Proper C string handling with null-termination and memory allocation
- **WIT Bindgen Integration**: Generated C bindings from WIT interface definitions
- **Build System**: Added `just` tasks for C plugin development (`just dl-wasi-sdk`, `just c-wit-bindgen-plugins`)
- **Testing**: Added end-to-end tests for C plugins with full CI integration

## 📚 Documentation

- Comprehensive C plugin development guide in `c_modules/README.md`
- Updated main README with C plugin information
- Added development workflow documentation

## 🧪 Testing

- Added e2e tests for C echo plugin functionality
- Split test infrastructure for better organization
- CI integration for C plugin builds

## 📦 Resources

### C Tooling

- [From the WebAssembly Component Model section for C tooling](https://component-model.bytecodealliance.org/language-support/c.html)
- [WASI SDK](https://github.com/WebAssembly/wasi-sdk)
- [WIT Bindgen](https://github.com/bytecodealliance/wit-bindgen)

This feature enables developers to write plugins in C, providing more language options for the WebAssembly Component Model REPL ecosystem while maintaining the same plugin interface and functionality as Rust implementations.