### PR TITLE
Add Pre-release Workflow with WASM File Uploads

### DIFF
--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -2,7 +2,26 @@ name: rust-host
 on: [push, pull_request]
 
 jobs:
+  # https://github.com/marketplace/actions/skip-duplicate-actions
+  pre_job:
+    # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          # Skip a workflow run if the same workflow is already running
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/README.md"]'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   build-and-test:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Set variables based on OS and architecture for just dl-wasi-sdk
@@ -43,3 +62,35 @@ jobs:
         run: just test
       - name: Test with wasm from http server (if it fails, you need to publish a new version of pluginlab)
         run: just test-e2e-pluginlab-http
+
+      - name: Build plugins in release mode (for pre-release)
+        if: github.ref_type == 'tag'
+        run: just build-plugins-release
+      - name: Prepare wasm files (for pre-release)
+        if: github.ref_type == 'tag'
+        run: ./scripts/prepare-wasm-files.sh --mode release --target-dir ./tmp/plugins
+      - name: Cache wasm files (for pre-release)
+        if: github.ref_type == 'tag'
+        id: cache-wasm-files
+        uses: actions/cache@v4
+        with:
+          path: ./tmp/plugins
+          key: ${{ runner.os }}-wasm-files-${{ github.sha }}
+
+  pre-release:
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - name: Restore cached wasm files
+        id: cache-wasm-files-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ./tmp/plugins
+          key: ${{ runner.os }}-wasm-files-${{ github.sha }}
+      - name: Pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./tmp/plugins/*.wasm

--- a/.github/workflows/web-host.yml
+++ b/.github/workflows/web-host.yml
@@ -2,7 +2,26 @@ name: web-host
 on: [push, pull_request]
 
 jobs:
+  # https://github.com/marketplace/actions/skip-duplicate-actions
+  pre_job:
+    # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          # Skip a workflow run if the same workflow is already running
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/README.md"]'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   build:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Set variables based on OS and architecture for just dl-wasi-sdk

--- a/README.md
+++ b/README.md
@@ -357,6 +357,35 @@ More about the [SpiderMonkey runtime embedding](https://github.com/bytecodeallia
 
 Coming.
 
+## CI
+
+### Testing
+
+The `pluginlab` binary is built and tested e2e (using `rexpect` library).
+
+The `web-host` is built and tested e2e (using [playwright](https://playwright.dev/)).
+
+### Deployment
+
+The `web-host` is automatically deployed to github pages when pushed on the `master` branch, containing the latest `wasm` versions of the plugins available at https://topheman.github.io/webassembly-component-model-experiments/plugins.
+
+### Pre-release
+
+https://github.com/topheman/webassembly-component-model-experiments/releases
+
+When a git tag is pushed, a pre-release is prepared on github, linked to the tag, containing the `wasm` files for the plugins and the repl-logic, in order to version those. That way, you can use an old binary of `pluginlab` against the correct versions of the plugins:
+
+```sh
+pluginlab\
+  --repl-logic https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/repl_logic_guest.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_greet.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_ls.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_echo.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_weather.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_cat.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin-echo-c.wasm\
+  --allow-all
+```
 
 ## Developer experience
 

--- a/crates/pluginlab/README.md
+++ b/crates/pluginlab/README.md
@@ -51,7 +51,7 @@ cargo install pluginlab
 
 ## Usage
 
-Run the CLI host, loading the plugins from the web (you can also load them from local files).
+Run the CLI host, loading the latest versions of the plugins from the web (you can also load them from local files).
 
 ```bash
 pluginlab\
@@ -74,7 +74,6 @@ Other flags:
 - `--allow-all`: allows all permissions (same as all the flags above), short: `-A`
 - `--help`: displays manual
 - `--debug`: run the host in debug mode (by default, the host runs in release mode)
-
 
 <details>
 <summary>🚀 Example of running the CLI host</summary>
@@ -124,3 +123,23 @@ Hello, Tophe!
 repl(0)>
 </pre>
 </details>
+
+### Versioning
+
+The plugins are also versioned in [github releases](https://github.com/topheman/webassembly-component-model-experiments/releases), you can use them if you want to use an old version of the plugins.
+
+<summary>
+  <details>
+    <summary>Example of running the CLI host with old versions of the plugins (if you have an old version of <code>pluginlab</code></summary>
+    <pre>
+pluginlab\
+  --repl-logic https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/repl_logic_guest.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_greet.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_ls.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_echo.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_weather.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_cat.wasm\
+  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin-echo-c.wasm\
+  --allow-all
+    </pre>
+</summary>

--- a/justfile
+++ b/justfile
@@ -67,12 +67,14 @@ build-release: build-repl-logic-guest-release build-plugins-release build-c-plug
 # Build all plugins in debug mode
 build-plugins:
     #!/usr/bin/env bash
+    just build-repl-logic-guest
     just build-rust-plugins
     just build-c-plugins
 
 # Build all plugins in release mode
 build-plugins-release:
     #!/usr/bin/env bash
+    just build-repl-logic-guest-release
     just build-rust-plugins-release
     just build-c-plugins
 


### PR DESCRIPTION
### Summary
Adds automatic pre-release creation with WASM files when git tags are pushed, enabling versioned plugin and repl-logic components.

### Changes
- **CI/CD**: Added pre-release job to upload WASM files as GitHub release assets on git tags
- **Optimization**: Added duplicate action skipping to prevent redundant workflow runs
- **Docs**: Added CI section to README with usage examples
- **Build**: Enhanced `justfile` to include repl-logic-guest in plugin builds

### Usage
```bash
pluginlab \
  --repl-logic https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/repl_logic_guest.wasm \
  --plugins https://github.com/topheman/webassembly-component-model-experiments/releases/download/pluginlab@0.4.1/plugin_greet.wasm \
  # ... other plugins
  --allow-all
```

### Testing
- ✅ CI workflows updated
- ✅ Documentation added
- ✅ Build system enhanced

No breaking changes - purely additive feature.