### PR TITLE
Add Homebrew Support and Cross-Compilation Pipeline

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,4 +1,4 @@
-# inspired by https://github.com/topheman/update-homebrew-tap-playground/blob/master/.github/workflows/cross-compile.yml# inspired by https://github.com/topheman/update-homebrew-tap-playground/blob/master/.github/workflows/cross-compile.yml
+# inspired by https://github.com/topheman/update-homebrew-tap-playground/blob/master/.github/workflows/cross-compile.yml
 name: Cross-Compile
 
 on: [push]
@@ -52,7 +52,8 @@ jobs:
         with:
           path: ./compressed
           key: ${{ matrix.platform.target }}-compressed-binaries-${{ github.sha }}
-  upload-archives: # will be changed for release-draft
+  upload-archives:
+    if: false # This step is totally skipped, activate the workflow outside of a tag (for debug purposes)
     needs: build
     name: Upload archive for build ${{ matrix.platform.target }}
     strategy:
@@ -75,4 +76,43 @@ jobs:
           path: ./compressed/
           name: ${{ env.BINARY_NAME }}-${{ matrix.platform.target }}.tar.gz
           retention-days: 10
-
+  create-release-draft-if-not-exist:
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create release draft
+        uses: topheman/create-release-if-not-exist@v1
+        with:
+          args: ${{ github.ref_name }} --draft --generate-notes
+  upload-artifacts-to-release-draft:
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    needs: create-release-draft-if-not-exist
+    env:
+      RELEASE_NAME: ${{ github.ref_name }}
+    name: Upload artifacts to release draft ${{ matrix.platform.target }}
+    strategy:
+      matrix:
+        platform:
+          - target: x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu
+          - target: x86_64-apple-darwin
+          - target: aarch64-apple-darwin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore cached compressed binaries
+        uses: actions/cache/restore@v4
+        with:
+          path: ./compressed
+          key: ${{ matrix.platform.target }}-compressed-binaries-${{ github.sha }}
+      - name: Upload artifacts to release draft
+        run: |
+          gh release upload ${{ env.RELEASE_NAME }} ./compressed/${{ env.BINARY_NAME }}-${{ matrix.platform.target }}.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -23,10 +23,10 @@ jobs:
       run: rustup target add x86_64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin
 
     - name: Check out source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Check
-      run: cargo check
+      run: cargo check -p pluginlab
 
     - name: Build
       run: cargo build -p pluginlab --release --target x86_64-unknown-linux-gnu --target x86_64-apple-darwin --target aarch64-apple-darwin

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,4 +1,4 @@
-# inspired by https://github.com/topheman/update-homebrew-tap-playground/blob/master/.github/workflows/cross-compile.yml
+# inspired by https://github.com/topheman/update-homebrew-tap-playground/blob/master/.github/workflows/cross-compile.yml# inspired by https://github.com/topheman/update-homebrew-tap-playground/blob/master/.github/workflows/cross-compile.yml
 name: Cross-Compile
 
 on: [push]
@@ -9,87 +9,70 @@ env:
 
 jobs:
   build:
-    if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest
+    name: Cross-Compile ${{ matrix.platform.target }}
+    strategy:
+      matrix:
+        platform:
 
+          - runs-on: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runs-on: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runs-on: macos-14
+            target: x86_64-apple-darwin
+          - runs-on: macos-14
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.platform.runs-on }}
     steps:
-
-    - name: Set up MacOS Cross Compiler
-      uses: Timmmm/setup-osxcross@v2
-      with:
-        osx-version: "12.3"
-
-    - name: Install Rustup targets
-      run: rustup target add x86_64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin
-
-    - name: Check out source code
-      uses: actions/checkout@v4
-
-    - name: Check
-      run: cargo check -p pluginlab
-
-    - name: Build
-      run: cargo build -p pluginlab --release --target x86_64-unknown-linux-gnu --target x86_64-apple-darwin --target aarch64-apple-darwin
-
-    - name: Generate completions
-      run: |
-        mkdir -p ./target/x86_64-unknown-linux-gnu/release/completions/{zsh,bash,fish}
-        ./target/x86_64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} generate-completions --shell zsh > ./target/x86_64-unknown-linux-gnu/release/completions/zsh/_${{ env.BINARY_NAME }}
-        ./target/x86_64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} generate-completions --shell bash > ./target/x86_64-unknown-linux-gnu/release/completions/bash/${{ env.BINARY_NAME }}
-        ./target/x86_64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} generate-completions --shell fish > ./target/x86_64-unknown-linux-gnu/release/completions/fish/${{ env.BINARY_NAME }}.fish
-
-    - name: Copy completions
-      run: |
-        cp -r ./target/x86_64-unknown-linux-gnu/release/completions ./target/x86_64-apple-darwin/release/completions
-        cp -r ./target/x86_64-unknown-linux-gnu/release/completions ./target/aarch64-apple-darwin/release/completions
-
-    - name: Compress
-      run: |
-        rm -rf ./tmp
-        mkdir ./tmp
-        (cd target/x86_64-unknown-linux-gnu/release && tar -cvf ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu.tar.gz ${{ env.BINARY_NAME }} completions && mv ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu.tar.gz ../../../tmp)
-        (cd target/x86_64-apple-darwin/release && tar -cvf ${{ env.BINARY_NAME }}-x86_64-apple-darwin.tar.gz ${{ env.BINARY_NAME }} completions && mv ${{ env.BINARY_NAME }}-x86_64-apple-darwin.tar.gz ../../../tmp)
-        (cd target/aarch64-apple-darwin/release && tar -cvf ${{ env.BINARY_NAME }}-aarch64-apple-darwin.tar.gz ${{ env.BINARY_NAME }} completions && mv ${{ env.BINARY_NAME }}-aarch64-apple-darwin.tar.gz ../../../tmp)
-
-    - name: Calculate sha256
-      run: |
-        shasum -a 256 ./tmp/${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu.tar.gz >> ./tmp/sha256.txt
-        shasum -a 256 ./tmp/${{ env.BINARY_NAME }}-x86_64-apple-darwin.tar.gz >> ./tmp/sha256.txt
-        shasum -a 256 ./tmp/${{ env.BINARY_NAME }}-aarch64-apple-darwin.tar.gz >> ./tmp/sha256.txt
-    - name: Cache
-      if: github.ref_type == 'tag'
-      id: cache-cross-compiled-artifacts
-      uses: actions/cache@v4
-      with:
-        path: ./tmp
-        key: ${{ runner.os }}-cross-compiled-artifacts-${{ github.sha }}
-
-  draft-release:
-    if: github.ref_type == 'tag'
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          command: build
+          target: ${{ matrix.platform.target }}
+          args: "--locked --release -p pluginlab"
+          strip: true
+      - name: Generate completions
+        run: |
+          mkdir -p ./tmp/${{ matrix.platform.target }}
+          cp target/${{ matrix.platform.target }}/release/${{ env.BINARY_NAME }} ./tmp/${{ matrix.platform.target }}/${{ env.BINARY_NAME }}
+          mkdir -p ./tmp/${{ matrix.platform.target }}/completions/{zsh,bash,fish}
+          ./tmp/${{ matrix.platform.target }}/${{ env.BINARY_NAME }} generate-completions --shell zsh > ./tmp/${{ matrix.platform.target }}/completions/zsh/_${{ env.BINARY_NAME }}
+          ./tmp/${{ matrix.platform.target }}/${{ env.BINARY_NAME }} generate-completions --shell bash > ./tmp/${{ matrix.platform.target }}/completions/bash/${{ env.BINARY_NAME }}
+          ./tmp/${{ matrix.platform.target }}/${{ env.BINARY_NAME }} generate-completions --shell fish > ./tmp/${{ matrix.platform.target }}/completions/fish/${{ env.BINARY_NAME }}.fish
+      - name: Compress
+        run: |
+          mkdir -p ./compressed
+          cd ./tmp/${{ matrix.platform.target }}
+          tar -cvf ${{ env.BINARY_NAME }}-${{ matrix.platform.target }}.tar.gz ${{ env.BINARY_NAME }} completions
+          mv ${{ env.BINARY_NAME }}-${{ matrix.platform.target }}.tar.gz ../../compressed
+      - name: Cache compressed binaries
+        uses: actions/cache@v4
+        with:
+          path: ./compressed
+          key: ${{ matrix.platform.target }}-compressed-binaries-${{ github.sha }}
+  upload-archives: # will be changed for release-draft
     needs: build
-    env:
-      RELEASE_NAME: ${{ github.ref_name }}
+    name: Upload archive for build ${{ matrix.platform.target }}
+    strategy:
+      matrix:
+        platform:
+          - target: x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu
+          - target: x86_64-apple-darwin
+          - target: aarch64-apple-darwin
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Restore cached cross-compiled artifacts
-        id: cache-cross-compiled-artifacts-restore
+      - name: Restore cached compressed binaries
         uses: actions/cache/restore@v4
         with:
-          path: ./tmp
-          key: ${{ runner.os }}-cross-compiled-artifacts-${{ github.sha }}
-      - name: Create release draft if it doesn't exist
-        uses: topheman/create-release-if-not-exist@v1
+          path: ./compressed
+          key: ${{ matrix.platform.target }}-compressed-binaries-${{ github.sha }}
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
         with:
-          args: ${{ env.RELEASE_NAME }} --draft --generate-notes
-      - name: Upload Binaries
-        run: |
-          gh release upload ${{ env.RELEASE_NAME }} \
-            ./tmp/${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu.tar.gz \
-            ./tmp/${{ env.BINARY_NAME }}-x86_64-apple-darwin.tar.gz \
-            ./tmp/${{ env.BINARY_NAME }}-aarch64-apple-darwin.tar.gz \
-            ./tmp/sha256.txt
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: ./compressed/
+          name: ${{ env.BINARY_NAME }}-${{ matrix.platform.target }}.tar.gz
+          retention-days: 10
+

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   build:
+    if: github.ref_type == 'tag'
     name: Cross-Compile ${{ matrix.platform.target }}
     strategy:
       matrix:

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,0 +1,95 @@
+# inspired by https://github.com/topheman/update-homebrew-tap-playground/blob/master/.github/workflows/cross-compile.yml
+name: Cross-Compile
+
+on: [push]
+
+env:
+  CARGO_TERM_COLOR: always
+  BINARY_NAME: pluginlab
+
+jobs:
+  build:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Set up MacOS Cross Compiler
+      uses: Timmmm/setup-osxcross@v2
+      with:
+        osx-version: "12.3"
+
+    - name: Install Rustup targets
+      run: rustup target add x86_64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin
+
+    - name: Check out source code
+      uses: actions/checkout@v3
+
+    - name: Check
+      run: cargo check
+
+    - name: Build
+      run: cargo build -p pluginlab --release --target x86_64-unknown-linux-gnu --target x86_64-apple-darwin --target aarch64-apple-darwin
+
+    - name: Generate completions
+      run: |
+        mkdir -p ./target/x86_64-unknown-linux-gnu/release/completions/{zsh,bash,fish}
+        ./target/x86_64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} generate-completions --shell zsh > ./target/x86_64-unknown-linux-gnu/release/completions/zsh/_${{ env.BINARY_NAME }}
+        ./target/x86_64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} generate-completions --shell bash > ./target/x86_64-unknown-linux-gnu/release/completions/bash/${{ env.BINARY_NAME }}
+        ./target/x86_64-unknown-linux-gnu/release/${{ env.BINARY_NAME }} generate-completions --shell fish > ./target/x86_64-unknown-linux-gnu/release/completions/fish/${{ env.BINARY_NAME }}.fish
+
+    - name: Copy completions
+      run: |
+        cp -r ./target/x86_64-unknown-linux-gnu/release/completions ./target/x86_64-apple-darwin/release/completions
+        cp -r ./target/x86_64-unknown-linux-gnu/release/completions ./target/aarch64-apple-darwin/release/completions
+
+    - name: Compress
+      run: |
+        rm -rf ./tmp
+        mkdir ./tmp
+        (cd target/x86_64-unknown-linux-gnu/release && tar -cvf ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu.tar.gz ${{ env.BINARY_NAME }} completions && mv ${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu.tar.gz ../../../tmp)
+        (cd target/x86_64-apple-darwin/release && tar -cvf ${{ env.BINARY_NAME }}-x86_64-apple-darwin.tar.gz ${{ env.BINARY_NAME }} completions && mv ${{ env.BINARY_NAME }}-x86_64-apple-darwin.tar.gz ../../../tmp)
+        (cd target/aarch64-apple-darwin/release && tar -cvf ${{ env.BINARY_NAME }}-aarch64-apple-darwin.tar.gz ${{ env.BINARY_NAME }} completions && mv ${{ env.BINARY_NAME }}-aarch64-apple-darwin.tar.gz ../../../tmp)
+
+    - name: Calculate sha256
+      run: |
+        shasum -a 256 ./tmp/${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu.tar.gz >> ./tmp/sha256.txt
+        shasum -a 256 ./tmp/${{ env.BINARY_NAME }}-x86_64-apple-darwin.tar.gz >> ./tmp/sha256.txt
+        shasum -a 256 ./tmp/${{ env.BINARY_NAME }}-aarch64-apple-darwin.tar.gz >> ./tmp/sha256.txt
+    - name: Cache
+      if: github.ref_type == 'tag'
+      id: cache-cross-compiled-artifacts
+      uses: actions/cache@v4
+      with:
+        path: ./tmp
+        key: ${{ runner.os }}-cross-compiled-artifacts-${{ github.sha }}
+
+  draft-release:
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      RELEASE_NAME: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore cached cross-compiled artifacts
+        id: cache-cross-compiled-artifacts-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ./tmp
+          key: ${{ runner.os }}-cross-compiled-artifacts-${{ github.sha }}
+      - name: Create release draft if it doesn't exist
+        uses: topheman/create-release-if-not-exist@v1
+        with:
+          args: ${{ env.RELEASE_NAME }} --draft --generate-notes
+      - name: Upload Binaries
+        run: |
+          gh release upload ${{ env.RELEASE_NAME }} \
+            ./tmp/${{ env.BINARY_NAME }}-x86_64-unknown-linux-gnu.tar.gz \
+            ./tmp/${{ env.BINARY_NAME }}-x86_64-apple-darwin.tar.gz \
+            ./tmp/${{ env.BINARY_NAME }}-aarch64-apple-darwin.tar.gz \
+            ./tmp/sha256.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
+    if: false # TODO: remove
     runs-on: ubuntu-latest
     steps:
       - name: Set variables based on OS and architecture for just dl-wasi-sdk

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
-    if: false # TODO: remove
     runs-on: ubuntu-latest
     steps:
       - name: Set variables based on OS and architecture for just dl-wasi-sdk

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -83,6 +83,7 @@ jobs:
     env:
       RELEASE_NAME: ${{ github.ref_name }}
     steps:
+      - uses: actions/checkout@v4
       - name: Restore cached wasm files
         id: cache-wasm-files-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -80,6 +80,8 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     needs: build-and-test
+    env:
+      RELEASE_NAME: ${{ github.ref_name }}
     steps:
       - name: Restore cached wasm files
         id: cache-wasm-files-restore
@@ -87,8 +89,12 @@ jobs:
         with:
           path: ./tmp/plugins
           key: ${{ runner.os }}-wasm-files-${{ github.sha }}
-      - name: Release draft
-        uses: softprops/action-gh-release@v2
+      - name: Create release draft if it doesn't exist
+        uses: topheman/create-release-if-not-exist@v1
         with:
-          draft: true
-          files: ./tmp/plugins/*.wasm
+          args: ${{ env.RELEASE_NAME }} --draft --generate-notes
+      - name: Upload wasm files to release draft
+        run: |
+          gh release upload ${{ env.RELEASE_NAME }} ./tmp/plugins/*.wasm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -15,12 +15,13 @@ jobs:
       - name: Checkout source repo
         uses: actions/checkout@v4
       - name: Update Homebrew Formula
-        uses: topheman/update-homebrew-tap@v1
+        uses: topheman/update-homebrew-tap@v2
         with:
           formula-target-repository: topheman/homebrew-tap
           formula-target-file: Formula/pluginlab.rb
           tar-files: |
             {
+              "linuxArm": "https://github.com/topheman/webassembly-component-model-experiments/releases/download/${{ github.ref_name }}/pluginlab-aarch64-unknown-linux-gnu.tar.gz",
               "linuxIntel": "https://github.com/topheman/webassembly-component-model-experiments/releases/download/${{ github.ref_name }}/pluginlab-x86_64-unknown-linux-gnu.tar.gz",
               "macArm": "https://github.com/topheman/webassembly-component-model-experiments/releases/download/${{ github.ref_name }}/pluginlab-aarch64-apple-darwin.tar.gz",
               "macIntel": "https://github.com/topheman/webassembly-component-model-experiments/releases/download/${{ github.ref_name }}/pluginlab-x86_64-apple-darwin.tar.gz"

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,36 @@
+name: Update Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-homebrew-tap:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # ✅ minimal required for pushing commits
+
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+      - name: Update Homebrew Formula
+        uses: topheman/update-homebrew-tap@v1
+        with:
+          formula-target-repository: topheman/homebrew-tap
+          formula-target-file: Formula/pluginlab.rb
+          tar-files: |
+            {
+              "linuxIntel": "https://github.com/topheman/webassembly-component-model-experiments/releases/download/${{ github.ref_name }}/pluginlab-x86_64-unknown-linux-gnu.tar.gz",
+              "macArm": "https://github.com/topheman/webassembly-component-model-experiments/releases/download/${{ github.ref_name }}/pluginlab-aarch64-apple-darwin.tar.gz",
+              "macIntel": "https://github.com/topheman/webassembly-component-model-experiments/releases/download/${{ github.ref_name }}/pluginlab-x86_64-apple-darwin.tar.gz"
+            }
+          metadata: |
+            {
+              "version": "${{ github.ref_name }}",
+              "binaryName": "pluginlab",
+              "description": "Terminal REPL with sandboxed multi-language plugin system - unified codebase runs in CLI (Rust) and web (TypeScript)",
+              "homepage": "https://github.com/topheman/webassembly-component-model-experiments",
+              "license": "MIT"
+            }
+          github-token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/web-host.yml
+++ b/.github/workflows/web-host.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    if: false # TODO: remove
     runs-on: ubuntu-latest
     steps:
       - name: Set variables based on OS and architecture for just dl-wasi-sdk

--- a/.github/workflows/web-host.yml
+++ b/.github/workflows/web-host.yml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: false # TODO: remove
     runs-on: ubuntu-latest
     steps:
       - name: Set variables based on OS and architecture for just dl-wasi-sdk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1500,7 @@ version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "reqwest",
  "rexpect",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -65,11 +65,18 @@ In the last seven years I've done a few projects involving rust and WebAssembly:
 
 ### pluginlab (rust) - REPL cli host
 
-#### Install
+#### Install the binary
+
+**Using cargo (from source)**
 
 ```bash
-# Install the pluginlab binary
 cargo install pluginlab
+```
+
+**Using homebrew**
+
+```bash
+brew install topheman/tap/pluginlab
 ```
 
 #### Run

--- a/crates/pluginlab/Cargo.toml
+++ b/crates/pluginlab/Cargo.toml
@@ -24,6 +24,7 @@ clap = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 reqwest = "0.12.20"
+clap_complete = "4.5"
 
 [build-dependencies]
 wasmtime = { workspace = true }

--- a/crates/pluginlab/README.md
+++ b/crates/pluginlab/README.md
@@ -45,8 +45,16 @@ More details on the github repo: [topheman/webassembly-component-model-experimen
 
 ## Install
 
+**Using cargo (from source)**
+
 ```bash
 cargo install pluginlab
+```
+
+**Using homebrew**
+
+```bash
+brew install topheman/tap/pluginlab
 ```
 
 ## Usage

--- a/crates/pluginlab/src/cli.rs
+++ b/crates/pluginlab/src/cli.rs
@@ -1,16 +1,19 @@
-use clap::Parser;
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
     /// Paths or URLs to WebAssembly plugin files
     #[arg(long)]
     pub plugins: Vec<String>,
 
     /// Path or URL to WebAssembly REPL logic file
     #[arg(long)]
-    pub repl_logic: String,
+    pub repl_logic: Option<String>,
 
     #[arg(long, default_value_t = false)]
     pub debug: bool,
@@ -45,4 +48,21 @@ pub struct Cli {
         conflicts_with = "allow_write"
     )]
     pub allow_all: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Generate completions for your own shell (shipped with the homebrew version)
+    GenerateCompletions {
+        /// Specify which shell you target - accepted values: bash, fish, zsh
+        #[arg(long, value_enum)]
+        shell: AvailableShells,
+    },
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum AvailableShells {
+    Bash,
+    Fish,
+    Zsh,
 }


### PR DESCRIPTION
This PR adds comprehensive cross-compilation support and Homebrew distribution capabilities to the `pluginlab` crate.

## 🚀 Main Features

### 1. Generate Completions Command
- Added `generate-completions` subcommand to `pluginlab` CLI
- Supports bash, fish, and zsh shell completions
- Uses `clap_complete` crate for generation
- Completions are bundled with cross-compiled binaries for Homebrew distribution
- **Inspiration**: This feature is inspired by a similar implementation in my previous project [`snake-pipe-rust`](https://github.com/topheman/snake-pipe-rust?tab=readme-ov-file#shell-completions), where shell completions are automatically installed with Homebrew and can be generated manually for other installation methods

### 2. Cross-Compilation Pipeline
- **New workflow**: `.github/workflows/cross-compile.yml`
- Uses [`houseabsolute/actions-rust-cross@v1`](https://github.com/houseabsolute/actions-rust-cross) for efficient cross-compilation
- **Targets supported**:
  - `x86_64-unknown-linux-gnu` (Linux Intel)
  - `aarch64-unknown-linux-gnu` (Linux ARM)
  - `x86_64-apple-darwin` (macOS Intel)
  - `aarch64-apple-darwin` (macOS ARM)
- **Features**:
  - Binaries are stripped for smaller size
  - Generated completions are bundled with each binary
  - Archives are created as `.tar.gz` files
  - Caching for faster builds

### 3. Release Management
- **Enhanced release workflow**: Updated `.github/workflows/rust-host.yml`
- Uses [`topheman/create-release-if-not-exist@v1`](https://github.com/topheman/create-release-if-not-exist) to allow multiple jobs to upload to the same release
- Both WASM files and cross-compiled binaries (generated in different jobs) are uploaded to [releases](https://github.com/topheman/webassembly-component-model-experiments/releases)
- Release artifacts include:
  - WASM plugin files (existing)
  - Cross-compiled binaries with completions (new)

### 4. Homebrew Integration
- **New workflow**: `.github/workflows/update-homebrew-tap.yml`
- Automatically updates Homebrew formula when releases are published
- Uses [`topheman/update-homebrew-tap@v2`](https://github.com/topheman/update-homebrew-tap)
- Updates formula in [`topheman/homebrew-tap`](https://github.com/topheman/homebrew-tap) repository
- Supports multiple target architectures for universal compatibility

## 📦 Installation Options

Users can now install `pluginlab` via:

```bash
# From source (existing)
cargo install pluginlab

# Via Homebrew (new)
brew install topheman/tap/pluginlab
```

## 🔧 Technical Changes

### CLI Enhancements
- Added `clap_complete` dependency for shell completion generation
- Restructured CLI to support subcommands
- `--repl-logic` is now optional (only required for REPL mode)
- New `generate-completions` subcommand with shell selection

### Workflow Improvements
- Cross-compilation runs on multiple platforms (Ubuntu, macOS, ARM runners)
- Efficient caching strategy for compiled artifacts
- Parallel upload of artifacts to releases
- Automatic Homebrew formula updates on release

## 🎯 Benefits

1. **Better Developer Experience**: Shell completions for all supported shells
2. **Wider Distribution**: Homebrew makes installation easier for macOS users
3. **Cross-Platform Support**: Native binaries for all major platforms
4. **Automated Releases**: Streamlined release process with automatic Homebrew updates
5. **Performance**: Stripped binaries and efficient caching reduce build times

## 🔗 Custom GitHub Actions Used

This implementation leverages the following custom GitHub actions I've created:

- [`topheman/create-release-if-not-exist@v1`](https://github.com/topheman/create-release-if-not-exist) - Allows multiple jobs to upload to the same release
- [`topheman/update-homebrew-tap@v2`](https://github.com/topheman/update-homebrew-tap) - Automatically updates Homebrew formulas

I also used [`topheman/update-homebrew-tap-playground`](https://github.com/topheman/update-homebrew-tap-playground) as a playground to test those in isolation.

---

This PR significantly improves the distribution and usability of `pluginlab` by providing native binaries for main platforms and seamless Homebrew integration, while maintaining the existing functionality and adding shell completions for better developer experience.
